### PR TITLE
Add "Refresh" menu option

### DIFF
--- a/github-notifications.1min.swift
+++ b/github-notifications.1min.swift
@@ -131,6 +131,7 @@ let showCountBadge = false
     print("---")
     print("\(notifications.count) unread notification\(notifications.count == 1 ? "" : "s") | href=https://github.com/notifications")
     print("View Notifications on GitHub... | href=https://github.com/notifications alternate=true")
+    print("Refresh | href=bitbar://refreshPlugin?name=github-notifications.?*.swift")
     print("---")
 
     for repositoryName in repositoryNames {


### PR DESCRIPTION
github-notifications is a great bitbar plugin, but I prefer to set the pull interval to a longer value (5 minutes), and instead I added an option to refresh on demand. Feel free to include it in your version, or not.